### PR TITLE
sign new PGP keys update azure artifacts and maven central azure devops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.moesif.api</groupId>
     <artifactId>moesifapi</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.12</version>
     <packaging>jar</packaging>
     <name>moesifapi</name>
     <description>Java API Library for Moesif</description>


### PR DESCRIPTION
Bump version to trigger automatic build and deploy via Azure Devops release pipeline.
* I generated new Moesif PGP keys on 20210511 (20210512 UTC). 
* Need to update azure artifacts as well as sonatype nexus (mavencentral repo.maven.apache.org ) so that latest version published utilizes the latest PGP keys
* v 1.6.12 should get signed and deployed using the new keys.
* No other code change from v1.6.11. v1.6.11 and previous versions are still valid signed.