### PR TITLE
Update to handle newer but unused config settings. update pom dependencies. more useful logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>com.moesif.api</groupId>
     <artifactId>moesifapi</artifactId>
-    <version>1.6.11</version>
+    <version>1.6.13</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.moesif.api</groupId>
     <artifactId>moesifapi</artifactId>
-    <version>1.6.12</version>
+    <version>1.6.13</version>
     <packaging>jar</packaging>
     <name>moesifapi</name>
     <description>Java API Library for Moesif</description>
@@ -37,33 +37,26 @@
         </developer>
     </developers>
 
-    <repositories>
-        <repository>
-            <id>moesif</id>
-            <name>Moesif</name>
-            <url>https://pkgs.dev.azure.com/Moesif/9143e1fb-e3b8-4475-ae87-caec5435d218/_packaging/moesif/maven/v1</url>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>com.moesif.unirest</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.1</version>
+            <version>2.9.10.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -93,7 +86,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -103,7 +96,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -124,7 +117,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -139,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -159,7 +152,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.6</version>
+                <version>1.6.8</version>
                 <extensions>false</extensions>
                 <executions>
                     <execution>

--- a/src/main/java/com/moesif/api/controllers/APIController.java
+++ b/src/main/java/com/moesif/api/controllers/APIController.java
@@ -452,8 +452,6 @@ public class APIController extends BaseController implements IAPIController {
                         appConfigModel = parseAppConfigModel(respBodyIs);
                         respBodyIs.close();
                     } catch (Exception e) {
-                        if (e.toString().toLowerCase().contains("Unrecognized field".toLowerCase()))
-                            logger.info("The AppConfig contains value not seen before. Check for newer version of this sdk");
                         logger.warning("Invalid AppConfig JSON: " + e.getMessage());
                     }
                     logger.info("App Config Model returned is " + appConfigModel);

--- a/src/main/java/com/moesif/api/controllers/BaseController.java
+++ b/src/main/java/com/moesif/api/controllers/BaseController.java
@@ -12,6 +12,10 @@ import com.moesif.api.http.client.HttpCallBack;
 import com.moesif.api.http.client.UnirestClient;
 import com.moesif.api.http.response.HttpResponse;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
 public abstract class BaseController {
     /**
      * Private variable to keep shared reference of client instance
@@ -75,7 +79,15 @@ public abstract class BaseController {
             throws APIException {
         //get response status code to validate
         int responseCode = response.getStatusCode();
-        if ((responseCode < 200) || (responseCode > 206)) //[200,206] = HTTP OK
-            throw new APIException("HTTP Response Not OK", context);
+        if ((responseCode < 200) || (responseCode > 206)) {//[200,206] = HTTP OK
+            String responseBody = "";
+            try {
+                String b = new BufferedReader(new InputStreamReader(response.getRawBody()))
+                                            .lines().collect(Collectors.joining("\n"));
+                if (null != b)
+                    responseBody = b.length() > 400 ? b.substring(0, 400) : b;
+            } catch (Exception ex) {}
+            throw new APIException("HTTP Response [" + responseCode + "] Not OK: " + responseBody, context);
+        }
     }
 }

--- a/src/main/java/com/moesif/api/models/AppConfigModel.java
+++ b/src/main/java/com/moesif/api/models/AppConfigModel.java
@@ -110,6 +110,46 @@ public class AppConfigModel
         this.companySampleRate = value;
     }
 
+    /** SETTER
+     * this value is not used
+     * @param value the value to set
+     */
+    @JsonSetter("block_bot_traffic")
+    public void setBlockBotTraffic(Object value) {
+    }
+
+    /** SETTER
+     * this value is not used
+     * @param value the value to set
+     */
+    @JsonSetter("user_rules")
+    public void setUserRules(Object value) {
+    }
+
+    /** SETTER
+     * this value is not used
+     * @param value the value to set
+     */
+    @JsonSetter("ip_addresses_blocked_by_name")
+    public void setIpAddressBlockedByName(Object value) {
+    }
+
+    /** SETTER
+     * this value is not used
+     * @param value the value to set
+     */
+    @JsonSetter("regex_config")
+    public void setRegexConfig(Object value) {
+    }
+
+    /** SETTER
+     * this value is not used
+     * @param value the value to set
+     */
+    @JsonSetter("company_rules")
+    public void setCompanyRules(Object value) {
+    }
+
     @Override
     public String toString(){
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/moesif/api/models/AppConfigModel.java
+++ b/src/main/java/com/moesif/api/models/AppConfigModel.java
@@ -6,12 +6,14 @@
 package com.moesif.api.models;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class AppConfigModel
         implements java.io.Serializable {
     private String orgId;
@@ -108,46 +110,6 @@ public class AppConfigModel
     @JsonSetter("company_sample_rate")
     public void setCompanySampleRate (Map<String, Integer>  value) {
         this.companySampleRate = value;
-    }
-
-    /** SETTER
-     * this value is not used
-     * @param value the value to set
-     */
-    @JsonSetter("block_bot_traffic")
-    public void setBlockBotTraffic(Object value) {
-    }
-
-    /** SETTER
-     * this value is not used
-     * @param value the value to set
-     */
-    @JsonSetter("user_rules")
-    public void setUserRules(Object value) {
-    }
-
-    /** SETTER
-     * this value is not used
-     * @param value the value to set
-     */
-    @JsonSetter("ip_addresses_blocked_by_name")
-    public void setIpAddressBlockedByName(Object value) {
-    }
-
-    /** SETTER
-     * this value is not used
-     * @param value the value to set
-     */
-    @JsonSetter("regex_config")
-    public void setRegexConfig(Object value) {
-    }
-
-    /** SETTER
-     * this value is not used
-     * @param value the value to set
-     */
-    @JsonSetter("company_rules")
-    public void setCompanyRules(Object value) {
     }
 
     @Override

--- a/src/main/java/com/moesif/api/models/UserBuilder.java
+++ b/src/main/java/com/moesif/api/models/UserBuilder.java
@@ -44,7 +44,7 @@ public class UserBuilder {
      * @return itself
      */
     public UserBuilder modifiedTime(Date modifiedTime) {
-        UserModel.setMetadata(modifiedTime);
+        UserModel.setModifiedTime(modifiedTime);
         return this;
     }
 

--- a/src/test/java/com/moesif/api/controllers/APIControllerTest.java
+++ b/src/test/java/com/moesif/api/controllers/APIControllerTest.java
@@ -629,7 +629,12 @@ public class APIControllerTest extends ControllerTestBase {
         // Test the header x-moesif-config-etag
         assertNotNull(httpResponse.getResponse().getHeaders().get("x-moesif-config-etag"));
         // Test the raw body
-        assertNotNull(httpResponse.getResponse().getRawBody());
+        InputStream bodyIs = httpResponse.getResponse().getRawBody();
+        assertNotNull(bodyIs);
+        AppConfigModel appConfig = APIController.parseAppConfigModel(bodyIs);
+        bodyIs.close();
+        assertNotNull(appConfig);
+
     }
 
     /**


### PR DESCRIPTION
Changes:
* Fixed warning about unknown moesif app config such as `block_bot_traffic`. Also added unit test to detect this.
* If HTTP call to moesif fails, print better response message and give status code
* Newer versions of dependencies in POM.xml esp jackson-databind - which had security advisory.
* Updated pom to remove azure artifacts moesif repo, as all binaries are available in sonatype nexus mavencentral 
* Bugfix `UserModel.setMetadata` -> `UserModel.setModifiedTime`
* bumped to version: 1.6.13