### PR TITLE
Fix: Maven Central Link as Bintray is no longer live

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-﻿Copyright (c) 2019 Moesif, Inc
+﻿Copyright (c) 2024 Moesif, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -637,11 +637,11 @@ mvn test
 ```
 
 [ico-built-for]: https://img.shields.io/badge/built%20for-java-blue.svg
-[ico-version]: https://api.bintray.com/packages/moesif/maven/moesifapi/images/download.svg
+[ico-version]: https://img.shields.io/maven-central/v/com.moesif.api/moesifapi
 [ico-license]: https://img.shields.io/badge/License-Apache%202.0-green.svg
 [ico-source]: https://img.shields.io/github/last-commit/moesif/moesifapi-java.svg?style=social
 
 [link-built-for]: https://www.java.com/en/
-[link-package]: https://bintray.com/moesif/maven/moesifapi/_latestVersion
+[link-package]: https://search.maven.org/artifact/com.moesif.api/moesifapi
 [link-license]: https://raw.githubusercontent.com/Moesif/moesifapi-java/master/LICENSE
 [link-source]: https://github.com/moesif/moesifapi-java


### PR DESCRIPTION
1. Remove Bintray Link which is no longer active
2. Update License year