### PR TITLE
#188498051 Add methods to for the /v1/action and /v1/action/batch endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.moesif.api</groupId>
     <artifactId>moesifapi</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <packaging>jar</packaging>
     <name>moesifapi</name>
     <description>Java API Library for Moesif</description>

--- a/src/main/java/com/moesif/api/controllers/APIController.java
+++ b/src/main/java/com/moesif/api/controllers/APIController.java
@@ -152,6 +152,82 @@ public class APIController extends BaseController implements IAPIController {
     }
 
     /**
+     * Send a single custom action to the API.
+     *
+     * @param body The ActionModel object to send.
+     * @throws Throwable if an error occurs during the API call.
+     */
+    public void createAction(final ActionModel body) throws Throwable {
+        APICallBackCatcher<HttpResponse> callback = new APICallBackCatcher<HttpResponse>();
+        createActionAsync(body, callback);
+        if (!callback.isSuccess())
+            throw callback.getError();
+        callback.getResult();
+    }
+
+    /**
+     * Send a single custom action to the API asynchronously.
+     *
+     * @param body     The ActionModel object to send.
+     * @param callBack Called after the HTTP response is received.
+     * @throws JsonProcessingException if an error occurs during serialization.
+     */
+    public void createActionAsync(
+            final ActionModel body,
+            final APICallBack<HttpResponse> callBack
+    ) throws JsonProcessingException {
+
+        QueryInfo qInfo = getQueryInfo("/v1/actions");
+
+        // Prepare and invoke the API call request to fetch the response
+        final HttpRequest _request = getClientInstance().postBody(
+                qInfo._queryUrl,
+                qInfo._headers,
+                APIHelper.serialize(body)
+        );
+
+        executeRequestAsync(_request, callBack);
+    }
+
+    /**
+     * Send multiple custom actions to the API in a single batch.
+     *
+     * @param body The list of ActionModel objects to send.
+     * @throws Throwable if an error occurs during the API call.
+     */
+    public void createActionsBatch(final List<ActionModel> body) throws Throwable {
+        APICallBackCatcher<HttpResponse> callback = new APICallBackCatcher<HttpResponse>();
+        createActionsBatchAsync(body, callback);
+        if (!callback.isSuccess())
+            throw callback.getError();
+        callback.getResult();
+    }
+
+    /**
+     * Send multiple custom actions to the API in a single batch asynchronously.
+     *
+     * @param body     The list of ActionModel objects to send.
+     * @param callBack Called after the HTTP response is received.
+     * @throws JsonProcessingException if an error occurs during serialization.
+     */
+    public void createActionsBatchAsync(
+            final List<ActionModel> body,
+            final APICallBack<HttpResponse> callBack
+    ) throws JsonProcessingException {
+
+        QueryInfo qInfo = getQueryInfo("/v1/actions/batch");
+
+        // Prepare and invoke the API call request to fetch the response
+        final HttpRequest _request = getClientInstance().postBody(
+                qInfo._queryUrl,
+                qInfo._headers,
+                APIHelper.serialize(body)
+        );
+
+        executeRequestAsync(_request, callBack);
+    }
+
+    /**
      * Update a Single User
      * @param    body    The user to update
      * @throws Throwable on error updating user

--- a/src/main/java/com/moesif/api/models/ActionModel.java
+++ b/src/main/java/com/moesif/api/models/ActionModel.java
@@ -1,0 +1,141 @@
+package com.moesif.api.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Map;
+
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = ActionModel.Builder.class)
+public class ActionModel {
+    private final String actionName;
+    private final String userId;
+    private final String companyId;
+    private final String transactionId;
+    private final String sessionToken;
+    private final String subscriptionId;
+    private final Map<String, Object> metadata;
+    private final ActionRequestModel request;
+
+    private ActionModel(Builder builder) {
+        this.actionName = builder.actionName;
+        this.userId = builder.userId;
+        this.companyId = builder.companyId;
+        this.transactionId = builder.transactionId;
+        this.sessionToken = builder.sessionToken;
+        this.subscriptionId = builder.subscriptionId;
+        this.metadata = builder.metadata;
+        this.request = builder.request;
+    }
+
+    public String getActionName() {
+        return actionName;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getCompanyId() {
+        return companyId;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public ActionRequestModel getRequest() {
+        return request;
+    }
+
+    // In the progressive enhancement of the Moesif API, the ActionModel class is introduced using
+    // immutable data structures and a static inner Builder class along with simplified Jackson boilerplate
+
+    // Old Builder pattern for constructing an existing Model type
+    // CompanyModel company = new CompanyBuilder()
+    //    .companyId("company-123")
+    //    .metadata(customMetadata)
+    //    .build();
+
+    // New way of constructing an ActionModel is very similar to the old way but with a static inner Builder class
+    // This checks required fields and results in an immutable output for more rigorous error checking and clearer code
+    // ActionRequestModel request = new ActionRequestModel.Builder("https://example.com")
+    //    .setUserAgentString("Mozilla/5.0")
+    //    .build();
+    //
+    // ActionModel action = new ActionModel.Builder("Clicked Sign Up", request)
+    //    .setUserId("user-123")
+    //    .setMetadata(customMetadata)
+    //    .build();
+    @JsonPOJOBuilder(withPrefix = "set")
+    public static class Builder {
+        private final String actionName;
+        private String userId;
+        private String companyId;
+        private String transactionId;
+        private String sessionToken;
+        private String subscriptionId;
+        private Map<String, Object> metadata;
+        private final ActionRequestModel request;
+
+        public Builder(String actionName, ActionRequestModel request) {
+            if (actionName == null || actionName.isEmpty()) {
+                throw new IllegalArgumentException("action_name is required");
+            }
+            if (request == null) {
+                throw new IllegalArgumentException("request is required");
+            }
+            this.actionName = actionName;
+            this.request = request;
+        }
+
+        public Builder setUserId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder setCompanyId(String companyId) {
+            this.companyId = companyId;
+            return this;
+        }
+
+        public Builder setTransactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public Builder setSessionToken(String sessionToken) {
+            this.sessionToken = sessionToken;
+            return this;
+        }
+
+        public Builder setSubscriptionId(String subscriptionId) {
+            this.subscriptionId = subscriptionId;
+            return this;
+        }
+
+        public Builder setMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public ActionModel build() {
+            return new ActionModel(this);
+        }
+    }
+}
+

--- a/src/main/java/com/moesif/api/models/ActionRequestModel.java
+++ b/src/main/java/com/moesif/api/models/ActionRequestModel.java
@@ -1,0 +1,72 @@
+package com.moesif.api.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = ActionRequestModel.Builder.class)
+public class ActionRequestModel {
+    private final String uri;
+    private final String userAgentString;
+    private final String ipAddress;
+    private final String time;
+
+    private ActionRequestModel(Builder builder) {
+        this.uri = builder.uri;
+        this.userAgentString = builder.userAgentString;
+        this.ipAddress = builder.ipAddress;
+        this.time = builder.time;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getUserAgentString() {
+        return userAgentString;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "set")
+    public static class Builder {
+        private final String uri;
+        private String userAgentString;
+        private String ipAddress;
+        private String time;
+
+        public Builder(String uri) {
+            if (uri == null || uri.isEmpty()) {
+                throw new IllegalArgumentException("uri is required");
+            }
+            this.uri = uri;
+        }
+
+        public Builder setUserAgentString(String userAgentString) {
+            this.userAgentString = userAgentString;
+            return this;
+        }
+
+        public Builder setIpAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+            return this;
+        }
+
+        public Builder setTime(String time) {
+            this.time = time;
+            return this;
+        }
+
+        public ActionRequestModel build() {
+            return new ActionRequestModel(this);
+        }
+    }
+}
+

--- a/src/test/java/com/moesif/api/controllers/APIControllerTest.java
+++ b/src/test/java/com/moesif/api/controllers/APIControllerTest.java
@@ -510,6 +510,148 @@ public class APIControllerTest extends ControllerTestBase {
     }
 
     /**
+     * Test creating a single Action synchronously.
+     * @throws Throwable
+     */
+    @Test
+    public void testCreateAction() throws Throwable {
+        ActionRequestModel requestContext = new ActionRequestModel.Builder("https://acmeinc.com/pricing")
+                .setUserAgentString("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+                .build();
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("button_label", "Get Started");
+        metadata.put("sign_up_method", "Google SSO");
+        ActionModel action = new ActionModel.Builder("Clicked Sign Up", requestContext)
+                .setUserId("12345")
+                .setCompanyId("67890")
+                .setTransactionId("a3765025-46ec-45dd-bc83-b136c8d1d257")
+                .setMetadata(metadata)
+                .build();
+
+        controller.setHttpCallBack(httpResponse);
+        controller.createAction(action);
+
+        assertEquals("Status is not 201",
+                201, httpResponse.getResponse().getStatusCode());
+    }
+
+    /**
+     * Test creating a single Action asynchronously.
+     * @throws Throwable
+     */
+    @Test
+    public void testCreateActionAsync() throws Throwable {
+        final CountDownLatch lock = new CountDownLatch(1);
+
+        ActionRequestModel requestContext = new ActionRequestModel.Builder("https://acmeinc.com/pricing")
+                .setUserAgentString("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+                .build();
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("button_label", "Get Started");
+        metadata.put("sign_up_method", "Google SSO");
+        ActionModel action = new ActionModel.Builder("Clicked Sign Up", requestContext)
+                .setUserId("12345")
+                .setCompanyId("67890")
+                .setTransactionId("a3765025-46ec-45dd-bc83-b136c8d1d257")
+                .setMetadata(metadata)
+                .build();
+
+        APICallBack<HttpResponse> callBack = new APICallBack<HttpResponse>() {
+            public void onSuccess(HttpContext context, HttpResponse response) {
+                assertEquals("Status is not 201",
+                        201, context.getResponse().getStatusCode());
+                lock.countDown();
+            }
+
+            public void onFailure(HttpContext context, Throwable error) {
+                fail("Asynchronous call failed: " + error.getMessage());
+            }
+        };
+
+        controller.createActionAsync(action, callBack);
+        assertTrue("Async call did not complete in time", lock.await(10000, TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * Test creating multiple Actions in a batch synchronously.
+     * @throws Throwable
+     */
+    @Test
+    public void testCreateActionsBatch() throws Throwable {
+        // Create multiple ActionModels
+        List<ActionModel> actions = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            ActionRequestModel requestContext = new ActionRequestModel.Builder("https://acmeinc.com/pricing")
+                    .setUserAgentString("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+                    .build();
+
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("button_label", "Get Started " + i);
+            metadata.put("sign_up_method", "Google SSO");
+
+            ActionModel action = new ActionModel.Builder("Clicked Sign Up", requestContext)
+                    .setUserId("user_" + i)
+                    .setCompanyId("company_" + i)
+                    .setTransactionId(UUID.randomUUID().toString())
+                    .setMetadata(metadata)
+                    .build();
+
+            actions.add(action);
+        }
+
+        controller.setHttpCallBack(httpResponse);
+        controller.createActionsBatch(actions);
+
+        assertEquals("Status is not 201",
+                201, httpResponse.getResponse().getStatusCode());
+    }
+
+    /**
+     * Test creating multiple Actions in a batch asynchronously.
+     * @throws Throwable
+     */
+    @Test
+    public void testCreateActionsBatchAsync() throws Throwable {
+        final CountDownLatch lock = new CountDownLatch(1);
+
+        // Create multiple ActionModels
+        List<ActionModel> actions = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            ActionRequestModel requestContext = new ActionRequestModel.Builder("https://acmeinc.com/pricing")
+                    .setUserAgentString("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+                    .build();
+
+            Map<String, Object> metadata = new HashMap<>();
+            metadata.put("button_label", "Get Started " + i);
+            metadata.put("sign_up_method", "Google SSO");
+
+            ActionModel action = new ActionModel.Builder("Clicked Sign Up", requestContext)
+                    .setUserId("user_" + i)
+                    .setCompanyId("company_" + i)
+                    .setTransactionId(UUID.randomUUID().toString())
+                    .setMetadata(metadata)
+                    .build();
+
+            actions.add(action);
+        }
+
+        APICallBack<HttpResponse> callBack = new APICallBack<HttpResponse>() {
+            public void onSuccess(HttpContext context, HttpResponse response) {
+                assertEquals("Status is not 201",
+                        201, context.getResponse().getStatusCode());
+                lock.countDown();
+            }
+
+            public void onFailure(HttpContext context, Throwable error) {
+                fail("Asynchronous batch call failed: " + error.getMessage());
+            }
+        };
+
+        controller.createActionsBatchAsync(actions, callBack);
+        assertTrue("Async batch call did not complete in time", lock.await(10000, TimeUnit.MILLISECONDS));
+    }
+
+    /**
      * Update Single User via Injestion API
      * @throws Throwable
      */

--- a/src/test/java/com/moesif/api/testing/ActionModelTest.java
+++ b/src/test/java/com/moesif/api/testing/ActionModelTest.java
@@ -1,0 +1,157 @@
+package com.moesif.api.testing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moesif.api.models.ActionModel;
+import com.moesif.api.models.ActionRequestModel;
+import org.junit.Test;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+// ActionModelTest tests the ActionModel and ActionRequestModel classes more thoroughly
+// to validate the new model classes' compatibility
+public class ActionModelTest {
+
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        // Initialize ObjectMapper for JSON serialization
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void testActionRequestModelBuilderRequiredFields() {
+        // Test that providing null or empty uri throws an exception
+        try {
+            new ActionRequestModel.Builder(null).build();
+            fail("Expected IllegalArgumentException for null uri");
+        } catch (IllegalArgumentException e) {
+            assertEquals("uri is required", e.getMessage());
+        }
+
+        try {
+            new ActionRequestModel.Builder("").build();
+            fail("Expected IllegalArgumentException for empty uri");
+        } catch (IllegalArgumentException e) {
+            assertEquals("uri is required", e.getMessage());
+        }
+
+        // Test successful creation with required field
+        ActionRequestModel requestModel = new ActionRequestModel.Builder("https://example.com").build();
+        assertNotNull(requestModel);
+    }
+
+    @Test
+    public void testActionRequestModelBuilderOptionalFields() {
+        // Build ActionRequestModel with all fields
+        ActionRequestModel requestModel = new ActionRequestModel.Builder("https://example.com")
+                .setUserAgentString("Mozilla/5.0")
+                .setIpAddress("192.168.1.1")
+                .setTime("2023-10-05T12:34:56Z")
+                .build();
+
+        // Serialize to JSON and verify fields
+        try {
+            String json = objectMapper.writeValueAsString(requestModel);
+            assertTrue(json.contains("\"uri\":\"https://example.com\""));
+            assertTrue(json.contains("\"userAgentString\":\"Mozilla/5.0\""));
+            assertTrue(json.contains("\"ipAddress\":\"192.168.1.1\""));
+            assertTrue(json.contains("\"time\":\"2023-10-05T12:34:56Z\""));
+        } catch (JsonProcessingException e) {
+            fail("JSON serialization failed: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testActionModelBuilderRequiredFields() {
+        ActionRequestModel requestModel = new ActionRequestModel.Builder("https://example.com").build();
+
+        // Test that providing null or empty actionName throws an exception
+        try {
+            new ActionModel.Builder(null, requestModel).build();
+            fail("Expected IllegalArgumentException for null actionName");
+        } catch (IllegalArgumentException e) {
+            assertEquals("action_name is required", e.getMessage());
+        }
+
+        try {
+            new ActionModel.Builder("", requestModel).build();
+            fail("Expected IllegalArgumentException for empty actionName");
+        } catch (IllegalArgumentException e) {
+            assertEquals("action_name is required", e.getMessage());
+        }
+
+        // Test that providing null request throws an exception
+        try {
+            new ActionModel.Builder("Clicked Sign Up", null).build();
+            fail("Expected IllegalArgumentException for null request");
+        } catch (IllegalArgumentException e) {
+            assertEquals("request is required", e.getMessage());
+        }
+
+        // Test successful creation with required fields
+        ActionModel actionModel = new ActionModel.Builder("Clicked Sign Up", requestModel).build();
+        assertNotNull(actionModel);
+    }
+
+    @Test
+    public void testActionModelBuilderOptionalFields() {
+        ActionRequestModel requestModel = new ActionRequestModel.Builder("https://example.com")
+                .setUserAgentString("Mozilla/5.0")
+                .build();
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("button_label", "Get Started");
+        metadata.put("sign_up_method", "Google SSO");
+
+        // Build ActionModel with all fields
+        ActionModel actionModel = new ActionModel.Builder("Clicked Sign Up", requestModel)
+                .setUserId("12345")
+                .setCompanyId("67890")
+                .setTransactionId("a3765025-46ec-45dd-bc83-b136c8d1d257")
+                .setSessionToken("session-token")
+                .setSubscriptionId("subscription-id")
+                .setMetadata(metadata)
+                .build();
+
+        // Serialize to JSON and verify fields
+        try {
+            String json = objectMapper.writeValueAsString(actionModel);
+            assertTrue(json.contains("\"actionName\":\"Clicked Sign Up\""));
+            assertTrue(json.contains("\"userId\":\"12345\""));
+            assertTrue(json.contains("\"companyId\":\"67890\""));
+            assertTrue(json.contains("\"transactionId\":\"a3765025-46ec-45dd-bc83-b136c8d1d257\""));
+            assertTrue(json.contains("\"sessionToken\":\"session-token\""));
+            assertTrue(json.contains("\"subscriptionId\":\"subscription-id\""));
+            assertTrue(json.contains("\"metadata\":{\"button_label\":\"Get Started\",\"sign_up_method\":\"Google SSO\"}"));
+            assertTrue(json.contains("\"request\""));
+        } catch (JsonProcessingException e) {
+            fail("JSON serialization failed: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testActionModelSerialization() {
+        ActionRequestModel requestModel = new ActionRequestModel.Builder("https://example.com")
+                .setUserAgentString("Mozilla/5.0")
+                .build();
+
+        ActionModel actionModel = new ActionModel.Builder("Clicked Sign Up", requestModel)
+                .build();
+
+        // Expected JSON
+        String expectedJson = "{\"actionName\":\"Clicked Sign Up\",\"request\":{\"uri\":\"https://example.com\",\"userAgentString\":\"Mozilla/5.0\"}}";
+
+        try {
+            String json = objectMapper.writeValueAsString(actionModel);
+            assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(json));
+        } catch (JsonProcessingException e) {
+            fail("JSON serialization failed: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Add methods to for the /v1/action and /v1/action/batch endpoints

These use updated Jackson constructs to streamline the code and implement safer, immutable result model objects with a simple builder

In an effort to improve code quality without breaking anything, I made these new model classes more like the old ones appear to have been aiming for, a simple immutable model object with a clear builder to set optional fields, and these also add enforcement of required fields on construction but only for this new endpoint to avoid any unanticipated behavior changes in existing code