### PR TITLE
Fix app config refresh frequency from collector, update logger name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>com.moesif.api</groupId>
     <artifactId>moesifapi</artifactId>
-    <version>1.8.3</version>
+    <version>1.8.5</version>
 </dependency>
 ```
 
@@ -48,7 +48,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```gradle
-implementation 'com.moesif.api:moesifapi:1.8.3'
+implementation 'com.moesif.api:moesifapi:1.8.5'
 ```
 
 ## How to Use

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.moesif.api</groupId>
     <artifactId>moesifapi</artifactId>
-    <version>1.8.4</version>
+    <version>1.8.5</version>
     <packaging>jar</packaging>
     <name>moesifapi</name>
     <description>Java API Library for Moesif</description>

--- a/src/main/java/com/moesif/api/controllers/APIController.java
+++ b/src/main/java/com/moesif/api/controllers/APIController.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 public class APIController extends BaseController implements IAPIController {
     //private static variables for the singleton pattern
-    private static final Logger logger = Logger.getLogger(APIController.class.toString());
+    private static final Logger logger = Logger.getLogger(APIController.class.getName());
 
     private static final String APP_CONFIG_ETAG_HEADER = "x-moesif-config-etag";
 
@@ -446,7 +446,9 @@ public class APIController extends BaseController implements IAPIController {
         {
             getHttpCallBack().OnBeforeRequest(_request);
         }
-        
+        if (config.debug)
+            logger.info("Begin fetch App Config Sync: " + qInfo._queryUrl);
+
         // make the API call
         HttpResponse _response = getClientInstance().executeAsString(_request);
         
@@ -516,6 +518,8 @@ public class APIController extends BaseController implements IAPIController {
     ) throws JsonProcessingException {
         QueryInfo qInfo = getQueryInfo("/v1/config");
 
+        if (config.debug)
+            logger.info("Begin fetch App Config Async: " + qInfo._queryUrl);
         //prepare and invoke the API call request to fetch the response
         final HttpRequest _request = getClientInstance().get(qInfo._queryUrl, qInfo._headers, null);
 
@@ -737,7 +741,6 @@ public class APIController extends BaseController implements IAPIController {
                             }
 
                             appConfigEtag = newAppConfigEtag;
-                            lastAppConfigFetch = new Date().getTime();
                         }
                     }
                     else {
@@ -754,9 +757,8 @@ public class APIController extends BaseController implements IAPIController {
                         }
 
                         appConfigEtag = response.getHeaders().get(APP_CONFIG_ETAG_HEADER);
-                        lastAppConfigFetch = new Date().getTime();
-
                     }
+                    lastAppConfigFetch = new Date().getTime();
                 }
 
                 public void onFailure(HttpContext context, Throwable error) {

--- a/src/main/java/com/moesif/api/http/client/UnirestClient.java
+++ b/src/main/java/com/moesif/api/http/client/UnirestClient.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 public class UnirestClient implements HttpClient {
-    private static final Logger logger = Logger.getLogger(UnirestClient.class.toString());
+    private static final Logger logger = Logger.getLogger(UnirestClient.class.getName());
 
     static ObjectMapper objectMapper = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 


### PR DESCRIPTION
* Fix logic to fetch app config from collector api: update last fetched time, honor debounce interval (DEV-7549)
* Fix the logger names -> change from `class com.moesif.api.*` to `com.moesif.api.*` (remove the prefix `class<space>`
* Bump to version `1.8.5` including `README.md` (DEV-7547)